### PR TITLE
Feature/multitargets

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,4 +23,4 @@ options:
 - hostinfo.csv - hostinfo of all targets parsed
 - Directory (named by the hostname of the image) including:
   - hostinfo_\<hostname\>.csv - with information of hostname, domain, windows version, install date, language, timezone, ips and users
-  - otheroutput of different plugins (TODO)
+  - other output of different plugins (TODO)

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # kirby
-A cute script to create a timeline of a windows image, using dissect
+A cute script to parse several forensic artifacts of given windows (triage) images, using dissect
 
 ## Usage
 
 ```
-usage: kirby [-h] [--overwrite] [--dialect {excel,excel-tab,unix}] image_path
+usage: kirby [-h] [--overwrite] [--dialect {excel,excel-tab,unix}] [TARGETS ...]
 
-create a timeline of a windows image, using dissect
+parse forensic artifacts from windows images, using dissect
 
 positional arguments:
-  image_path
+  TARGETS               Path to single target or directory with multiple targets to parse
 
 options:
   -h, --help            show this help message and exit
@@ -19,6 +19,8 @@ options:
 ```
 
 ## Output
-Directory (named by the hostname of the image) including:
-- hostname.txt - with information of hostname, domain, windows version, install date, language, timezone, ips and users
-- otheroutput of different plugins (TODO)
+
+- hostinfo.csv - hostinfo of all targets parsed
+- Directory (named by the hostname of the image) including:
+  - hostinfo_\<hostname\>.csv - with information of hostname, domain, windows version, install date, language, timezone, ips and users
+  - otheroutput of different plugins (TODO)

--- a/kirby.py
+++ b/kirby.py
@@ -7,10 +7,9 @@ from utils import HostAnalyzer
 def main():
     args = utils.cli.arguments()
 
-    analyzer = HostAnalyzer(args.image_path, overwrite=args.overwrite)
-    analyzer.write_target_info()
-    analyzer.invoke_plugins()
-
+    analyzer = HostAnalyzer(args.targets, overwrite=args.overwrite)
+    analyzer.analyze_targets()
+    
 
 if __name__ == '__main__':
     coloredlogs.install(level='INFO')

--- a/utils/HostAnalyzer.py
+++ b/utils/HostAnalyzer.py
@@ -3,26 +3,42 @@ import shutil
 import sys
 import traceback
 
-from dissect.target import Target
-from dissect.target.exceptions import UnsupportedPluginError
 from flow.record.adapter.csvfile import CsvfileWriter
+from dissect.target import Target
+from dissect.target.exceptions import TargetError
+from dissect.target.exceptions import UnsupportedPluginError
 from dissect.target.helpers.record import TargetRecordDescriptor
-
+from dissect.target.tools.query import record_output
 from dissect.target.tools.info import (
     get_target_info
 )
 
-from utils import TxtFile
 from utils.cli import logger
 
+# changed "ips" type from "net.ipaddress[]" to "strings[]" from original dissect InfoRecord
+InfoRecord = TargetRecordDescriptor(
+    "target/info",
+    [
+        ("datetime", "last_activity"),
+        ("datetime", "install_date"),
+        ("string[]", "ips"),
+        ("string", "os_family"),
+        ("string", "os_version"),
+        ("string", "architecture"),
+        ("string[]", "language"),
+        ("string", "timezone"),
+        ("string[]", "disks"),
+        ("string[]", "volumes"),
+        ("string[]", "children"),
+    ],
+)
+
 class HostAnalyzer:
-    def __init__(self, image_path: str, overwrite: bool = False):
+    
+    def __init__(self, targets: str, overwrite: bool = False):
         super(HostAnalyzer, self).__init__()
-        self.path = image_path
-        self.__target = Target.open(image_path)
-        self.__target.apply()
         self.__overwrite = overwrite
-        self.__dst_dir = self.__create_destination_directory()
+        self.__targets = targets
         self.__PLUGINS = [
             "amcache_install",
             "adpolicy",
@@ -63,13 +79,34 @@ class HostAnalyzer:
             ##"usnjrnl" # takes a lot of time
         ]
 
-    def invoke_plugins(self):
-        for plugin in self.__PLUGINS:
-            self.invoke_plugin(plugin)
+        
+    # will enumerate all targets and create hostinfo as well as invoke all plugins for each target     
+    def analyze_targets(self):
+        filename = "hostinfo.csv"
+        writer = CsvfileWriter(filename,
+                               exclude=["_generated", "_source", "_classification", "_version"])
 
-    def invoke_plugin(self, plugin):
         try:
-            target = self.__target
+            for i, target in enumerate(Target.open_all(self.__targets)):
+                try:
+                    self.__dst_dir = self.__create_destination_directory(target)
+                    record = InfoRecord(**get_target_info(target), _target=target)
+                    writer.write(record)
+                    self.write_target_info(target)
+                    self.invoke_plugins(target)
+                except Exception as e:
+                    target.log.error(f"Exception in retrieving information for target: `%s`.: {e}", target)
+        except TargetError as e:
+            logger().error(e)
+
+
+    def invoke_plugins(self, target: Target):
+        for plugin in self.__PLUGINS:
+            self.invoke_plugin(target, plugin)
+
+
+    def invoke_plugin(self, target, plugin):
+        try:
             filename = plugin
             if isinstance(plugin, tuple):
                 filename = "_".join(plugin)
@@ -87,6 +124,7 @@ class HostAnalyzer:
             tb_str = traceback.format_exc()
             logger().error(f"{plugin}: An unexpected error occurred:\r\n {tb_str}")
 
+
     def write_csv(self, filename, records):
         if not filename.endswith(".csv"):
             filename += ".csv"
@@ -98,9 +136,10 @@ class HostAnalyzer:
             #logger().info(f"Enty {entry} in Records {records}")
             writer.write(entry)
 
-    def __create_destination_directory(self):
-        logger().info(f"found image with hostname '{self.__target.hostname}'; creating target directory for it")
-        dst = os.path.join(os.curdir, self.__target.hostname)
+
+    def __create_destination_directory(self, target: Target):
+        logger().info(f"found image with hostname '{target.hostname}'; creating target directory for it")
+        dst = os.path.join(os.curdir, target.hostname)
         if os.path.exists(dst):
             if self.__overwrite:
                 logger().info(f"target directory '{dst}' exists already, deleting it")
@@ -110,35 +149,16 @@ class HostAnalyzer:
                 sys.exit(1)
         os.makedirs(dst)
         return dst
-          
-    def write_target_info(self):
 
-        # changed "ips" type from "net.ipaddress[]" to "strings[]" from original dissect InfoRecord
-        InfoRecord = TargetRecordDescriptor(
-            "target/info",
-            [
-                ("datetime", "last_activity"),
-                ("datetime", "install_date"),
-                ("string[]", "ips"),
-                ("string", "os_family"),
-                ("string", "os_version"),
-                ("string", "architecture"),
-                ("string[]", "language"),
-                ("string", "timezone"),
-                ("string[]", "disks"),
-                ("string[]", "volumes"),
-                ("string[]", "children"),
-            ],
-        )
-          
+
+    def write_target_info(self, target: Target):
+        
         try:
-            record = InfoRecord(**get_target_info(self.__target), _target=self.__target)
-            filename = "hostinfo.csv"
+            record = InfoRecord(**get_target_info(target), _target=target)
+            filename = "hostinfo_" + target.hostname + ".csv"
             writer = CsvfileWriter(os.path.join(self.__dst_dir, filename),
                                exclude=["_generated", "_source", "_classification", "_version"])
             writer.write(record)
-
         except Exception as e:
             logger().error(e)
-            logger().debug("", exc_info=e)
 

--- a/utils/HostAnalyzer.py
+++ b/utils/HostAnalyzer.py
@@ -35,7 +35,7 @@ InfoRecord = TargetRecordDescriptor(
 
 class HostAnalyzer:
     
-    def __init__(self, targets: str, overwrite: bool = False):
+    def __init__(self, targets: list, overwrite: bool = False):
         super(HostAnalyzer, self).__init__()
         self.__overwrite = overwrite
         self.__targets = targets
@@ -87,12 +87,12 @@ class HostAnalyzer:
                                exclude=["_generated", "_source", "_classification", "_version"])
 
         try:
-            for i, target in enumerate(Target.open_all(self.__targets)):
+            for target in Target.open_all(self.__targets):
                 try:
                     self.__dst_dir = self.__create_destination_directory(target)
                     record = InfoRecord(**get_target_info(target), _target=target)
                     writer.write(record)
-                    self.write_target_info(target)
+                    self.__write_target_info(target)
                     self.invoke_plugins(target)
                 except Exception as e:
                     target.log.error(f"Exception in retrieving information for target: `%s`.: {e}", target)
@@ -151,11 +151,11 @@ class HostAnalyzer:
         return dst
 
 
-    def write_target_info(self, target: Target):
+    def __write_target_info(self, target: Target):
         
         try:
             record = InfoRecord(**get_target_info(target), _target=target)
-            filename = "hostinfo_" + target.hostname + ".csv"
+            filename = f"hostinfo_{target.hostname}.csv"
             writer = CsvfileWriter(os.path.join(self.__dst_dir, filename),
                                exclude=["_generated", "_source", "_classification", "_version"])
             writer.write(record)

--- a/utils/cli/__init__.py
+++ b/utils/cli/__init__.py
@@ -22,7 +22,7 @@ def arguments():
         prog="kirby",
         description="parse forensic artifacts from windows images, using dissect"
     )
-    parser.add_argument('targets', metavar="TARGETS", nargs="*", help="Path to single target or directory with multiple targets to parse")
+    parser.add_argument('targets', metavar="TARGETS", nargs="+", help="Path to single target or directory with multiple targets to parse")
     parser.add_argument('--overwrite', action='store_true', help='overwrite destination directory')
     parser.add_argument('--dialect',
                         choices=csv.list_dialects(),

--- a/utils/cli/__init__.py
+++ b/utils/cli/__init__.py
@@ -22,7 +22,7 @@ def arguments():
         prog="kirby",
         description="parse forensic artifacts from windows images, using dissect"
     )
-    parser.add_argument('targets', metavar="TARGETS", nargs="*", help="Targets to parse")
+    parser.add_argument('targets', metavar="TARGETS", nargs="*", help="Path to single target or directory with multiple targets to parse")
     parser.add_argument('--overwrite', action='store_true', help='overwrite destination directory')
     parser.add_argument('--dialect',
                         choices=csv.list_dialects(),

--- a/utils/cli/__init__.py
+++ b/utils/cli/__init__.py
@@ -20,14 +20,15 @@ def logger():
 def arguments():
     parser = argparse.ArgumentParser(
         prog="kirby",
-        description="create a timeline of a windows image, using dissect"
+        description="parse forensic artifacts from windows images, using dissect"
     )
-    parser.add_argument('image_path')
+    parser.add_argument('targets', metavar="TARGETS", nargs="*", help="Targets to parse")
     parser.add_argument('--overwrite', action='store_true', help='overwrite destination directory')
     parser.add_argument('--dialect',
                         choices=csv.list_dialects(),
                         default='unix',
                         help='select CSV dialect')
+    
     args = parser.parse_args()
 
     return args


### PR DESCRIPTION
This PR adds the capability to parse multiple targets (images, triage collections, ...) from a given path.
You can ether specify a single target via the path or a directory containing multiple images, triage collections from different hosts etc.

The output contains a "hostinfo.csv" with basic host information like, hostname, ip address, os version for all hosts that were parsed with the script, as well as an output directory for each host containing the output for all plugins that were run for the host, also including the "hostinfo_\<hostname\>.csv" containing basic host information only for the specific host.
```
.
├── DESKTOP-F6413S8
│   ├── activitiescache.csv
│   ├── bam.csv
│   ├── chrome_history.csv
│   ├── edge_history.csv
│   ├── firewall.csv
│   ├── hostinfo_DESKTOP-F6413S8.csv
│   ├── iexplore_history.csv
│   ├── muicache.csv
│   ├── powershell_history.csv
│   ├── prefetch.csv
│   ├── runkeys.csv
│   ├── services.csv
│   ├── shellbags.csv
│   ├── shimcache.csv
│   ├── tasks.csv
│   ├── usb.csv
│   ├── userassist.csv
│   └── users.csv
├── hostinfo.csv
└── WINDOWS11
    ├── activitiescache.csv
    ├── bam.csv
    ├── edge_history.csv
    ├── firefox_history.csv
    ├── firewall.csv
    ├── hostinfo_WINDOWS11.csv
    ├── iexplore_history.csv
    ├── muicache.csv
    ├── powershell_history.csv
    ├── prefetch.csv
    ├── runkeys.csv
    ├── services.csv
    ├── shellbags.csv
    ├── shimcache.csv
    ├── tasks.csv
    ├── usb.csv
    ├── userassist.csv
    └── users.csv

```


